### PR TITLE
Allow "%Y" in statusline format for displaying total number of lines

### DIFF
--- a/Documentation/dex.txt
+++ b/Documentation/dex.txt
@@ -719,6 +719,9 @@ statusline-left [" %f%s%m%r%s%M"]
 	@li %y
 	Cursor row.
 
+	@li %Y
+	Total rows in file.
+
 	@li %x
 	Cursor display column.
 

--- a/format-status.c
+++ b/format-status.c
@@ -100,6 +100,9 @@ void sf_format(struct formatter *f, char *buf, long size, const char *format)
 			case 'y':
 				add_status_format(f, "%d", v->cy + 1);
 				break;
+			case 'Y':
+				add_status_format(f, "%ld", v->buffer->nl);
+				break;
 			case 'x':
 				add_status_format(f, "%d", v->cx_display + 1);
 				break;

--- a/options.c
+++ b/options.c
@@ -160,7 +160,7 @@ static void syntax_changed(void)
 
 static bool validate_statusline_format(const char *value)
 {
-	static const char chars[] = "fmryxXpEMnstu%";
+	static const char chars[] = "fmryYxXpEMnstu%";
 	int i = 0;
 
 	while (value[i]) {


### PR DESCRIPTION
This allows displaying the total number of lines in the status line, for example: `set statusline-right "%y/%Y "`. Does `%Y` seem an appropriate character to use?
