### PR TITLE
Fix some format specifier and mismatched type warnings

### DIFF
--- a/cconv.c
+++ b/cconv.c
@@ -80,7 +80,7 @@ static void add_replacement(struct cconv *c)
 
 static size_t handle_invalid(struct cconv *c, const char *buf, size_t count)
 {
-	d_print("%d %ld\n", c->char_size, count);
+	d_print("%d %zd\n", c->char_size, count);
 	add_replacement(c);
 	if (c->char_size == 0) {
 		// converting from UTF-8
@@ -154,7 +154,7 @@ static size_t convert_incomplete(struct cconv *c, const char *input, size_t len)
 			skip = handle_invalid(c, c->tbuf, c->tcount);
 			c->tcount -= skip;
 			if (c->tcount > 0) {
-				d_print("tcount=%ld, skip=%ld\n", c->tcount, skip);
+				d_print("tcount=%zd, skip=%zd\n", c->tcount, skip);
 				memmove(c->tbuf, c->tbuf + skip, c->tcount);
 				continue;
 			}
@@ -162,7 +162,7 @@ static size_t convert_incomplete(struct cconv *c, const char *input, size_t len)
 		}
 		break;
 	}
-	d_print("%lu %lu\n", ipos, c->tcount);
+	d_print("%zu %zu\n", ipos, c->tcount);
 	return ipos;
 }
 

--- a/lock.c
+++ b/lock.c
@@ -66,7 +66,7 @@ static int lock_or_unlock(const char *filename, bool lock)
 {
 	int tries = 0;
 	int wfd, pid;
-	long size;
+	ssize_t size;
 	char *buf = NULL;
 
 	if (!file_locks) {


### PR DESCRIPTION
This fixes a few warnings that appear when building with GCC 4.8.1.
- cconv.c:83:2: warning: format '%ld' expects argument of type 'long int', but argument 3 has type 'size_t'
- cconv.c:157:5: warning: format '%ld' expects argument of type 'long int', but argument 2 has type 'size_t'
- cconv.c:157:5: warning: format '%ld' expects argument of type 'long int', but argument 3 has type 'size_t'
- cconv.c:165:2: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'size_t'
- cconv.c:165:2: warning: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'size_t'
- lock.c:113:2: warning: passing argument 2 of 'rewrite_lock_file' from incompatible pointer type
- lock.c:14:12: note: expected 'ssize_t *' but argument is of type 'long int *'
