### PR TITLE
Fix XML syntax file to highlight tag names according to the standard

### DIFF
--- a/share/syntax/xml
+++ b/share/syntax/xml
@@ -79,22 +79,20 @@ state comment
 
 state tag-start tag
 	char / close-tag
-	char -b a-zA-Z0-9_ tag-name
-	char " \t\n" tag-start
+	char -b a-zA-Z_: tag-name
 	char > text tag
 	eat tag-start error
 
 state close-tag tag
-	char -b a-zA-Z0-9_ close-tag-name
-	char " \t\n" close-tag
+	char -b a-zA-Z_: close-tag-name
 	eat text error
 
 state tag-name tag
-	char -b a-zA-Z0-9_ tag-name
+	char -b a-zA-Z0-9_:.- tag-name
 	noeat attrs
 
 state close-tag-name tag
-	char -b a-zA-Z0-9_ close-tag-name
+	char -b a-zA-Z0-9_:.- close-tag-name
 	noeat close-tag-end
 
 state close-tag-end special


### PR DESCRIPTION
I just noticed that the dex syntax highlighter shows dash characters in XML tag names as errors; even though they're valid according to the spec and are quite common in Android XML files.

Relevant sections of the spec:
- http://www.w3.org/TR/REC-xml/#d0e804
- http://www.w3.org/TR/REC-xml/#sec-starttags

This commit adds the dash character to the `tag-name` state and fixes a few other small details.
